### PR TITLE
Cosmos 404 On SF Redeploy Fix

### DIFF
--- a/src/Eshopworld.WorkerProcess/Stores/CosmosDbLeaseStore.cs
+++ b/src/Eshopworld.WorkerProcess/Stores/CosmosDbLeaseStore.cs
@@ -45,7 +45,7 @@ namespace EShopworld.WorkerProcess.Stores
                 Id = _options.Value.Collection
             };
 
-            collectionDefinition.PartitionKey.Paths.Add("/instanceId");
+            collectionDefinition.PartitionKey.Paths.Add("/leaseType");
 
             await _documentClient.CreateDocumentCollectionIfNotExistsAsync(
                 UriFactory.CreateDatabaseUri(_options.Value.Database),


### PR DESCRIPTION
InitialiseAsync on the CosmosDbLeaseStore uses instanceId as partiton key. We're experiencing an issue on WorkerLease TimerElapsed when app in one location tries to update a lease that was created in another or, more commonly, when an app is redeployed and Lease InstanceId is new.

CosmosDbLeaseStore.TryUpdateLeaseAsync attempts to replace the document after updating the instanceId. The documentClient ReplaceDocumentAsync will fail with a DocumentClientException and 404 Status code. This happens as instanceId is a partionkey and replacing instanceid will mean replace will always fail. Integration tests in solution will fail with same error.

leaseType would be a good candidate for partition key as redeployed apps/new instances will always search within lease type partition. No further issues discovered when db is initialised with this partition key.