### PR TITLE
#70177 LeaseExpired event not firing

### DIFF
--- a/src/Eshopworld.WorkerProcess/Configuration/ServiceConfigurationExtensions.cs
+++ b/src/Eshopworld.WorkerProcess/Configuration/ServiceConfigurationExtensions.cs
@@ -25,6 +25,8 @@ namespace EShopworld.WorkerProcess.Configuration
 
             services.TryAddSingleton<IAllocationDelay, ProportionalAllocationDelay>();
 
+            services.TryAddSingleton<ISlottedInterval, SlottedInterval>();
+
             services.TryAddSingleton<ILeaseAllocator, LeaseAllocator>();
 
             services.TryAddSingleton<ILeaseStore, CosmosDbLeaseStore>();

--- a/src/Eshopworld.WorkerProcess/IIntervalCalculator.cs
+++ b/src/Eshopworld.WorkerProcess/IIntervalCalculator.cs
@@ -1,0 +1,8 @@
+﻿using System;
+namespace EShopworld.WorkerProcess
+{
+    public interface ISlottedInterval
+    {
+        TimeSpan Calculate(DateTime time, TimeSpan interval);
+    }
+}

--- a/src/Eshopworld.WorkerProcess/SlottedInterval.cs
+++ b/src/Eshopworld.WorkerProcess/SlottedInterval.cs
@@ -1,0 +1,14 @@
+﻿using System;
+
+namespace EShopworld.WorkerProcess
+{
+    public class SlottedInterval: ISlottedInterval
+    {
+        public TimeSpan Calculate(DateTime time, TimeSpan interval)
+        {
+            return TimeSpan.FromMilliseconds(interval.TotalMilliseconds -
+                   time.TimeOfDay.TotalMilliseconds / interval.TotalMilliseconds % 1 *
+                   interval.TotalMilliseconds);
+        }
+    }
+}

--- a/src/Eshopworld.WorkerProcess/Stores/CosmosDbLease.cs
+++ b/src/Eshopworld.WorkerProcess/Stores/CosmosDbLease.cs
@@ -18,6 +18,8 @@ namespace EShopworld.WorkerProcess.Stores
         /// <inheritdoc />
         [JsonProperty("leasedUntil")]
         public DateTime? LeasedUntil { get; set; }
+        [JsonProperty("interval")]
+        public TimeSpan? Interval { get; set; }
         /// <inheritdoc />
         [JsonProperty("leaseType")]
         public string LeaseType { get; set; }

--- a/src/Eshopworld.WorkerProcess/Stores/CosmosDbLeaseStore.cs
+++ b/src/Eshopworld.WorkerProcess/Stores/CosmosDbLeaseStore.cs
@@ -82,7 +82,7 @@ namespace EShopworld.WorkerProcess.Stores
                     return new LeaseStoreResult(MapResource(response),
                         response.StatusCode == HttpStatusCode.OK);
                 }
-                catch (DocumentClientException ex) when (ex.StatusCode == HttpStatusCode.Conflict)
+                catch (DocumentClientException ex) when (ex.StatusCode == HttpStatusCode.Conflict || ex.StatusCode == HttpStatusCode.PreconditionFailed)
                 {
                     return new LeaseStoreResult(null, false);
                 }

--- a/src/Eshopworld.WorkerProcess/Stores/ILease.cs
+++ b/src/Eshopworld.WorkerProcess/Stores/ILease.cs
@@ -25,6 +25,11 @@ namespace EShopworld.WorkerProcess.Stores
         DateTime? LeasedUntil { get; set; }
 
         /// <summary>
+        /// The interval of the lease
+        /// </summary>
+        TimeSpan? Interval { get; set; }
+
+        /// <summary>
         /// The lease type
         /// </summary>
         string LeaseType { get; set; }

--- a/src/Eshopworld.WorkerProcess/WorkerLease.cs
+++ b/src/Eshopworld.WorkerProcess/WorkerLease.cs
@@ -93,10 +93,16 @@ namespace EShopworld.WorkerProcess
                 if (CurrentLease != null)
                     OnLeaseAllocated(CurrentLease.LeasedUntil.GetValueOrDefault());
 
-                _timer.Interval =
-                    CalculateTimerInterval(
+                if(CurrentLease?.LeasedUntil.HasValue ?? false)
+                {
+                    _timer.Interval = CurrentLease.Interval.Value.TotalMilliseconds;
+                }
+                else
+                {
+                    _timer.Interval = CalculateTimerInterval(
                         CurrentLease?.LeasedUntil ?? ServerDateTime.UtcNow,
                         _options.Value.LeaseInterval);
+                }
             }
             finally
             {

--- a/src/Eshopworld.WorkerProcess/WorkerLease.cs
+++ b/src/Eshopworld.WorkerProcess/WorkerLease.cs
@@ -21,6 +21,7 @@ namespace EShopworld.WorkerProcess
         private readonly ILeaseAllocator _leaseAllocator;
         private readonly IBigBrother _telemetry;
         private readonly ITimer _timer;
+        private readonly ISlottedInterval _slottedInterval;
 
         internal ILease CurrentLease;
 
@@ -28,12 +29,14 @@ namespace EShopworld.WorkerProcess
             IBigBrother telemetry,
             ILeaseAllocator leaseAllocator,
             ITimer timer,
+            ISlottedInterval slottedInterval,
             IOptions<WorkerLeaseOptions> options)
         {
             _telemetry = telemetry ?? throw new ArgumentNullException(nameof(telemetry));
             _leaseAllocator = leaseAllocator ?? throw new ArgumentNullException(nameof(leaseAllocator));
             _options = options ?? throw new ArgumentNullException(nameof(options));
             _timer = timer ?? throw new ArgumentNullException(nameof(timer));
+            _slottedInterval = slottedInterval ?? throw new ArgumentNullException(nameof(slottedInterval));
 
             InstanceId = Guid.NewGuid();
 
@@ -53,7 +56,7 @@ namespace EShopworld.WorkerProcess
             {
                 _timer.Elapsed += TimerElapsed;
 
-                _timer.Interval = CalculateTimerInterval(ServerDateTime.UtcNow, _options.Value.LeaseInterval);
+                _timer.Interval = _slottedInterval.Calculate(ServerDateTime.UtcNow, _options.Value.LeaseInterval).TotalMilliseconds;
                 _timer.Start();
             });
         }
@@ -99,9 +102,9 @@ namespace EShopworld.WorkerProcess
                 }
                 else
                 {
-                    _timer.Interval = CalculateTimerInterval(
+                    _timer.Interval = _slottedInterval.Calculate(
                         CurrentLease?.LeasedUntil ?? ServerDateTime.UtcNow,
-                        _options.Value.LeaseInterval);
+                        _options.Value.LeaseInterval).TotalMilliseconds;
                 }
             }
             finally
@@ -132,13 +135,6 @@ namespace EShopworld.WorkerProcess
         private protected void OnLeaseAllocated(DateTime leaseExpiry)
         {
             LeaseAllocated?.Invoke(this, new LeaseAllocatedEventArgs(leaseExpiry));
-        }
-
-        private static double CalculateTimerInterval(DateTime time, TimeSpan interval)
-        {
-            return interval.TotalMilliseconds -
-                   time.TimeOfDay.TotalMilliseconds / interval.TotalMilliseconds % 1 *
-                   interval.TotalMilliseconds;
         }
 
         [DebuggerStepThrough]

--- a/src/tests/EShopworld.WorkerProcess.IntegrationTests/WorkerLeaseTests.cs
+++ b/src/tests/EShopworld.WorkerProcess.IntegrationTests/WorkerLeaseTests.cs
@@ -178,11 +178,12 @@ namespace EShopworld.WorkerProcess.IntegrationTests
                 var telemetry = _serviceProvider.GetService<IBigBrother>();
                 var leaseStore = _serviceProvider.GetService<ILeaseStore>();
                 var propAllocDelay = _serviceProvider.GetService<IAllocationDelay>();
+                var slottedInterval = _serviceProvider.GetService<ISlottedInterval>();
                 var timer = _serviceProvider.GetService<ITimer>();
 
-                var leaseAllocator = new LeaseAllocator(telemetry, leaseStore, propAllocDelay, options);
+                var leaseAllocator = new LeaseAllocator(telemetry, leaseStore, slottedInterval, propAllocDelay, options);
 
-                var workerLease = new WorkerLease(telemetry, leaseAllocator, timer, options);
+                var workerLease = new WorkerLease(telemetry, leaseAllocator, timer, slottedInterval, options);
 
                 workerLease.LeaseAllocated += (sender, args) =>
                 {

--- a/src/tests/EShopworld.WorkerProcess.IntegrationTests/WorkerLeaseTests.cs
+++ b/src/tests/EShopworld.WorkerProcess.IntegrationTests/WorkerLeaseTests.cs
@@ -22,6 +22,7 @@ using Xunit.Abstractions;
 
 namespace EShopworld.WorkerProcess.IntegrationTests
 {
+    [Collection("WorkerLeases")]
     public class WorkerLeaseTests
     {
         private readonly ServiceProvider _serviceProvider;

--- a/src/tests/EShopworld.WorkerProcess.UnitTests/LeaseAllocatorTests.cs
+++ b/src/tests/EShopworld.WorkerProcess.UnitTests/LeaseAllocatorTests.cs
@@ -15,6 +15,7 @@ namespace EShopworld.WorkerProcess.UnitTests
     public class LeaseAllocatorTests
     {
         private readonly Mock<IAllocationDelay> _mockAllocationDelay;
+        private readonly Mock<ISlottedInterval> _mockSlottedInterval;
         private readonly Mock<IBigBrother> _mockTelemetry;
         private readonly Mock<ILeaseStore> _mockStore;
         private readonly WorkerLeaseOptions _options;
@@ -23,6 +24,7 @@ namespace EShopworld.WorkerProcess.UnitTests
         public LeaseAllocatorTests()
         {
             _mockAllocationDelay = new Mock<IAllocationDelay>();
+            _mockSlottedInterval = new Mock<ISlottedInterval>();
             _mockTelemetry = new Mock<IBigBrother>();
             _mockStore = new Mock<ILeaseStore>();
 
@@ -33,7 +35,7 @@ namespace EShopworld.WorkerProcess.UnitTests
                 WorkerType = "workertype"
             };
 
-            _leaseAllocator = new LeaseAllocator(_mockTelemetry.Object, _mockStore.Object, _mockAllocationDelay.Object,
+            _leaseAllocator = new LeaseAllocator(_mockTelemetry.Object, _mockStore.Object, _mockSlottedInterval.Object, _mockAllocationDelay.Object,
                 Options.Create(_options));
         }
 

--- a/src/tests/EShopworld.WorkerProcess.UnitTests/LeaseAllocatorTests.cs
+++ b/src/tests/EShopworld.WorkerProcess.UnitTests/LeaseAllocatorTests.cs
@@ -73,6 +73,7 @@ namespace EShopworld.WorkerProcess.UnitTests
                 InstanceId = Guid.NewGuid(),
                 LeasedUntil = currentDateTime.Subtract(new TimeSpan(1, 0, 0)),
                 Priority = _options.Priority + 1,
+                Interval = TimeSpan.FromMinutes(2),
                 LeaseType = _options.WorkerType
             };
 
@@ -85,6 +86,9 @@ namespace EShopworld.WorkerProcess.UnitTests
             _mockStore.SetupSequence(m => m.TryUpdateLeaseAsync(It.IsAny<ILease>()))
                 .ReturnsAsync(new LeaseStoreResult(lease, true))
                 .ReturnsAsync(new LeaseStoreResult(lease, true));
+
+            _mockSlottedInterval.Setup(m => m.Calculate(It.IsAny<DateTime>(), It.IsAny<TimeSpan>()))
+                .Returns(TimeSpan.FromMinutes(2));
 
             // Act
             var result = await _leaseAllocator.AllocateLeaseAsync(Guid.NewGuid());
@@ -163,6 +167,9 @@ namespace EShopworld.WorkerProcess.UnitTests
             _mockStore.SetupSequence(m => m.TryUpdateLeaseAsync(It.IsAny<ILease>()))
                 .ReturnsAsync(new LeaseStoreResult(lease, true))
                 .ReturnsAsync(new LeaseStoreResult(lease, true));
+
+            _mockSlottedInterval.Setup(m => m.Calculate(It.IsAny<DateTime>(), It.IsAny<TimeSpan>()))
+                .Returns(TimeSpan.FromMinutes(2));
 
             // Act
             var result = await _leaseAllocator.AllocateLeaseAsync(Guid.NewGuid());

--- a/src/tests/EShopworld.WorkerProcess.UnitTests/SlottedIntervalTests.cs
+++ b/src/tests/EShopworld.WorkerProcess.UnitTests/SlottedIntervalTests.cs
@@ -1,6 +1,6 @@
 ﻿using System;
+using System.Collections.Generic;
 using Eshopworld.Tests.Core;
-using EShopworld.WorkerProcess.Infrastructure;
 using FluentAssertions;
 using Xunit;
 
@@ -17,24 +17,36 @@ namespace EShopworld.WorkerProcess.UnitTests
         }
 
         [Theory, IsUnit]
-        [InlineData(637333444195566768L, 60000, 443.3231999996642)]     // 1 min
-        [InlineData(637333444195566768L, 300000, 180443.3232000065)]    // 5 min
-        [InlineData(637333444195566768L, 900000, 780443.3232000001)]    // 15 min
-        [InlineData(637333444195566768L, 3600000, 780443.3232)]         // 1 hour
-        [InlineData(630823248000000000L, 60000, 60000)]                 // 1 min
-        [InlineData(630823248000000000L, 300000, 300000)]               // 5 min
-        [InlineData(630823248000000000L, 900000, 900000)]               // 15 min
-        [InlineData(630823248000000000L, 3600000, 3600000)]             // 1 hour
-        public void TestInterval(long ticks, double interval, double expectedSlottedInterval)
+        [MemberData(nameof(Data))]
+        public void TestInterval(DateTime now, TimeSpan interval, double expectedSlottedInterval)
         {
             // Arrange
-            var now = new DateTime(ticks, DateTimeKind.Utc);
 
             // Act
-            var result = _slottedInterval.Calculate(now, TimeSpan.FromMilliseconds(interval));
+            var result = _slottedInterval.Calculate(now, interval);
 
             // Assert
             result.TotalMilliseconds.Should().BeApproximately(expectedSlottedInterval, _precision);
         }
+
+        private static DateTime OnTheHour = new DateTime(2000, 1, 1, 12, 0, 0);
+        private static DateTime NotOnTheHour = new DateTime(2000, 1, 1, 11, 20, 10, 255);
+        private static TimeSpan Interval_1Min = TimeSpan.FromMinutes(1);
+        private static TimeSpan Interval_5Min = TimeSpan.FromMinutes(5);
+        private static TimeSpan Interval_12Min = TimeSpan.FromMinutes(12);
+        private static TimeSpan Interval_1Hour = TimeSpan.FromHours(1);
+
+        public static IEnumerable<object[]> Data =>
+            new List<object[]>
+            {
+                new object[] { NotOnTheHour, Interval_1Min, 49744.99999999807 },
+                new object[] { NotOnTheHour, Interval_5Min, 289744.9999999964 },
+                new object[] { NotOnTheHour, Interval_12Min, 229744.99999999808 },
+                new object[] { NotOnTheHour, Interval_1Hour, 2389745.000000001 },
+                new object[] { OnTheHour, Interval_1Min, Interval_1Min.TotalMilliseconds },
+                new object[] { OnTheHour, Interval_5Min, Interval_5Min.TotalMilliseconds },
+                new object[] { OnTheHour, Interval_12Min, Interval_12Min.TotalMilliseconds },
+                new object[] { OnTheHour, Interval_1Hour, Interval_1Hour.TotalMilliseconds },
+            };
     }
 }

--- a/src/tests/EShopworld.WorkerProcess.UnitTests/SlottedIntervalTests.cs
+++ b/src/tests/EShopworld.WorkerProcess.UnitTests/SlottedIntervalTests.cs
@@ -1,0 +1,40 @@
+﻿using System;
+using Eshopworld.Tests.Core;
+using EShopworld.WorkerProcess.Infrastructure;
+using FluentAssertions;
+using Xunit;
+
+namespace EShopworld.WorkerProcess.UnitTests
+{
+    public class SlottedIntervalTests
+    {
+        private readonly SlottedInterval _slottedInterval;
+        private static float _precision = 0.01F;
+
+        public SlottedIntervalTests()
+        {
+            _slottedInterval = new SlottedInterval();
+        }
+
+        [Theory, IsUnit]
+        [InlineData(637333444195566768L, 60000, 443.3231999996642)]     // 1 min
+        [InlineData(637333444195566768L, 300000, 180443.3232000065)]    // 5 min
+        [InlineData(637333444195566768L, 900000, 780443.3232000001)]    // 15 min
+        [InlineData(637333444195566768L, 3600000, 780443.3232)]         // 1 hour
+        [InlineData(630823248000000000L, 60000, 60000)]                 // 1 min
+        [InlineData(630823248000000000L, 300000, 300000)]               // 5 min
+        [InlineData(630823248000000000L, 900000, 900000)]               // 15 min
+        [InlineData(630823248000000000L, 3600000, 3600000)]             // 1 hour
+        public void TestInterval(long ticks, double interval, double expectedSlottedInterval)
+        {
+            // Arrange
+            var now = new DateTime(ticks, DateTimeKind.Utc);
+
+            // Act
+            var result = _slottedInterval.Calculate(now, TimeSpan.FromMilliseconds(interval));
+
+            // Assert
+            result.TotalMilliseconds.Should().BeApproximately(expectedSlottedInterval, _precision);
+        }
+    }
+}

--- a/src/tests/EShopworld.WorkerProcess.UnitTests/TestLease.cs
+++ b/src/tests/EShopworld.WorkerProcess.UnitTests/TestLease.cs
@@ -9,6 +9,7 @@ namespace EShopworld.WorkerProcess.UnitTests
         public int Priority { get; set; }
         public Guid? InstanceId { get; set; }
         public DateTime? LeasedUntil { get; set; }
+        public TimeSpan? Interval { get; set; }
         public string LeaseType { get; set; }
     }
 }

--- a/src/tests/EShopworld.WorkerProcess.UnitTests/WorkerLeaseTests.cs
+++ b/src/tests/EShopworld.WorkerProcess.UnitTests/WorkerLeaseTests.cs
@@ -16,6 +16,7 @@ namespace EShopworld.WorkerProcess.UnitTests
     public class WorkerLeaseTests
     {
         private readonly Mock<ILeaseAllocator> _mockLeaseAllocator;
+        private readonly Mock<ISlottedInterval> _mockSlottedInterval;
         private readonly Mock<IBigBrother> _mockTelemetry;
         private readonly WorkerLeaseOptions _options;
         private readonly WorkerLease _workerLease;
@@ -24,6 +25,7 @@ namespace EShopworld.WorkerProcess.UnitTests
         public WorkerLeaseTests()
         {
             _mockLeaseAllocator = new Mock<ILeaseAllocator>();
+            _mockSlottedInterval = new Mock<ISlottedInterval>();
             _mockTelemetry = new Mock<IBigBrother>();
             _mockTimer = new Mock<ITimer>();
 
@@ -34,7 +36,11 @@ namespace EShopworld.WorkerProcess.UnitTests
                 WorkerType = "workertype"
             };
 
-            _workerLease = new WorkerLease(_mockTelemetry.Object, _mockLeaseAllocator.Object, _mockTimer.Object,
+            _workerLease = new WorkerLease(
+                _mockTelemetry.Object,
+                _mockLeaseAllocator.Object,
+                _mockTimer.Object,
+                _mockSlottedInterval.Object,
                 Options.Create(_options));
         }
         


### PR DESCRIPTION
This approach suggested by @chomick calculates the interval slot and stores it in the Lease document to avoid time drifts.

Implemented fix to catch the DocumentClientException with PreconditionFailed HTTP status.

Also added attribute to avoid parallelization of tests.
