### PR TITLE
Add integration test for many concurrent worker processes

### DIFF
--- a/src/Eshopworld.WorkerProcess/IWorkerLease.cs
+++ b/src/Eshopworld.WorkerProcess/IWorkerLease.cs
@@ -9,6 +9,12 @@ namespace EShopworld.WorkerProcess
         /// The instance id
         /// </summary>
         Guid InstanceId { get; }
+
+        /// <summary>
+        /// Priority
+        /// </summary>
+        int Priority { get; }
+        /// <summary>
         /// <summary>
         /// Start Leasing
         /// </summary>

--- a/src/Eshopworld.WorkerProcess/IWorkerLease.cs
+++ b/src/Eshopworld.WorkerProcess/IWorkerLease.cs
@@ -11,10 +11,6 @@ namespace EShopworld.WorkerProcess
         Guid InstanceId { get; }
 
         /// <summary>
-        /// Priority
-        /// </summary>
-        int Priority { get; }
-        /// <summary>
         /// <summary>
         /// Start Leasing
         /// </summary>

--- a/src/Eshopworld.WorkerProcess/IWorkerLease.cs
+++ b/src/Eshopworld.WorkerProcess/IWorkerLease.cs
@@ -1,6 +1,4 @@
 ﻿using System;
-using System.Threading.Tasks;
-
 namespace EShopworld.WorkerProcess
 {
     public interface IWorkerLease
@@ -9,7 +7,6 @@ namespace EShopworld.WorkerProcess
         /// The instance id
         /// </summary>
         Guid InstanceId { get; }
-
         /// <summary>
         /// Start Leasing
         /// </summary>

--- a/src/Eshopworld.WorkerProcess/IWorkerLease.cs
+++ b/src/Eshopworld.WorkerProcess/IWorkerLease.cs
@@ -11,7 +11,6 @@ namespace EShopworld.WorkerProcess
         Guid InstanceId { get; }
 
         /// <summary>
-        /// <summary>
         /// Start Leasing
         /// </summary>
         void StartLeasing();

--- a/src/Eshopworld.WorkerProcess/WorkerLease.cs
+++ b/src/Eshopworld.WorkerProcess/WorkerLease.cs
@@ -50,9 +50,6 @@ namespace EShopworld.WorkerProcess
         public Guid InstanceId { get; }
 
         /// <inheritdoc />
-        public int Priority => _options.Value.Priority;
-
-        /// <inheritdoc />
         public void StartLeasing()
         {
             OperationTelemetryHandler(() =>

--- a/src/Eshopworld.WorkerProcess/WorkerLease.cs
+++ b/src/Eshopworld.WorkerProcess/WorkerLease.cs
@@ -50,6 +50,9 @@ namespace EShopworld.WorkerProcess
         public Guid InstanceId { get; }
 
         /// <inheritdoc />
+        public int Priority => _options.Value.Priority;
+
+        /// <inheritdoc />
         public void StartLeasing()
         {
             OperationTelemetryHandler(() =>

--- a/src/tests/EShopworld.WorkerProcess.IntegrationTests/WorkerLeaseTests.cs
+++ b/src/tests/EShopworld.WorkerProcess.IntegrationTests/WorkerLeaseTests.cs
@@ -12,6 +12,7 @@ using EShopworld.WorkerProcess.Configuration;
 using EShopworld.WorkerProcess.Infrastructure;
 using EShopworld.WorkerProcess.Stores;
 using FluentAssertions;
+using FluentAssertions.Execution;
 using Microsoft.Azure.Documents;
 using Microsoft.Azure.Documents.Client;
 using Microsoft.Extensions.Configuration;
@@ -156,8 +157,12 @@ namespace EShopworld.WorkerProcess.IntegrationTests
             }
 
             // Assert
-            _allocatedList.Select(w=>w.InstanceId).Count().Should().Be(1);
-            _allocatedList.First().Priority.Should().Be(_workerLeases.Select(w => w.Priority).Min());
+            using (new AssertionScope())
+            {
+                _allocatedList.Select(w => w.InstanceId).Count().Should().Be(1);
+                _allocatedList.First().Priority.Should().Be(_workerLeases.Select(w => w.Priority).Min());
+            }
+           
         }
 
         [Fact, IsIntegration]

--- a/src/tests/EShopworld.WorkerProcess.IntegrationTests/appsettings.json
+++ b/src/tests/EShopworld.WorkerProcess.IntegrationTests/appsettings.json
@@ -13,7 +13,7 @@
     "LeasesCollection": "WorkerLeases"
   },
   "WorkerLeaseOptions": {
-    "LeaseType": "TestWorker",
+    "WorkerType": "TestWorker",
     "Priority": "0",
     "LeaseInterval": "0:01:00"
   }


### PR DESCRIPTION
Add an integration to run 30 concurrent worker process with random priorities
Ensure the priority of the acquired lease has always the minimum number(highest priority)