### PR TITLE
Task 98400 integration tests multi region

### DIFF
--- a/src/Eshopworld.WorkerProcess/WorkerLease.cs
+++ b/src/Eshopworld.WorkerProcess/WorkerLease.cs
@@ -129,7 +129,7 @@ namespace EShopworld.WorkerProcess
                 _telemetry.Publish(new LeaseExceptionEvent(ex));
 
                 throw new WorkerLeaseException(
-                    $"An unhandled exception occured executing operation [{memberName}]", ex);
+                    $"An unhandled exception occurred executing operation [{memberName}]", ex);
             }
         }
     }

--- a/src/tests/EShopworld.WorkerProcess.IntegrationTests/WorkerLeaseTests.cs
+++ b/src/tests/EShopworld.WorkerProcess.IntegrationTests/WorkerLeaseTests.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Threading;
@@ -14,7 +13,6 @@ using EShopworld.WorkerProcess.Infrastructure;
 using EShopworld.WorkerProcess.Stores;
 using FluentAssertions;
 using FluentAssertions.Execution;
-using Kusto.Cloud.Platform.Utils;
 using Microsoft.Azure.Documents;
 using Microsoft.Azure.Documents.Client;
 using Microsoft.Extensions.Configuration;
@@ -248,11 +246,10 @@ namespace EShopworld.WorkerProcess.IntegrationTests
             // assert that the lease is assigned to the same instances 
             using (new AssertionScope())
             {
-                _allocatedList.Should().HaveCount(3);
+                _allocatedList.Should().HaveCount(3); 
                 _allocatedList.Select(lease => lease.InstanceId).Distinct().Should().HaveCount(1);
-                _workerLeases // priority of the workerProcesses that got the lease should be 0
-                    .Where(kv => _allocatedList.Select(lease => lease.InstanceId).Contains(kv.Key.InstanceId))
-                    .Select(kv => kv.Value).Should().AllBeEquivalentTo(0);
+                _allocatedList.Select(lease => _workerLeases[lease]) // priority of the workerProcesses that got the lease should be 0
+                    .Should().AllBeEquivalentTo(0);
                 _expiredList.Should().NotBeEmpty();
             }
         }

--- a/src/tests/EShopworld.WorkerProcess.IntegrationTests/WorkerLeaseTests.cs
+++ b/src/tests/EShopworld.WorkerProcess.IntegrationTests/WorkerLeaseTests.cs
@@ -14,7 +14,6 @@ using EShopworld.WorkerProcess.Infrastructure;
 using EShopworld.WorkerProcess.Stores;
 using FluentAssertions;
 using FluentAssertions.Execution;
-using JetBrains.Annotations;
 using Microsoft.Azure.Documents;
 using Microsoft.Azure.Documents.Client;
 using Microsoft.Extensions.Configuration;

--- a/src/tests/EShopworld.WorkerProcess.UnitTests/WorkerLeaseTests.cs
+++ b/src/tests/EShopworld.WorkerProcess.UnitTests/WorkerLeaseTests.cs
@@ -66,7 +66,7 @@ namespace EShopworld.WorkerProcess.UnitTests
             // Assert
             eventFired.Should().BeTrue();
             _mockSlottedInterval.Verify(m => m.Calculate(new DateTime(2000, 1, 1, 12, 0, 0), TimeSpan.FromMinutes(2)));
-            _mockLeaseAllocator.Verify(m => m.ReleaseLeaseAsync(It.IsAny<ILease>()), Times.Never);
+            _mockLeaseAllocator.Verify(m => m.ReleaseLeaseAsync(It.IsAny<ILease>()));
         }
 
         [Fact, IsUnit]

--- a/src/tests/EShopworld.WorkerProcess.UnitTests/WorkerLeaseTests.cs
+++ b/src/tests/EShopworld.WorkerProcess.UnitTests/WorkerLeaseTests.cs
@@ -66,7 +66,7 @@ namespace EShopworld.WorkerProcess.UnitTests
             // Assert
             eventFired.Should().BeTrue();
             _mockSlottedInterval.Verify(m => m.Calculate(new DateTime(2000, 1, 1, 12, 0, 0), TimeSpan.FromMinutes(2)));
-            _mockLeaseAllocator.Verify(m => m.ReleaseLeaseAsync(It.IsAny<ILease>()));
+            _mockLeaseAllocator.Verify(m => m.ReleaseLeaseAsync(It.IsAny<ILease>()), Times.Never);
         }
 
         [Fact, IsUnit]


### PR DESCRIPTION
This PR contains two integration tests -
1. Multiple WP (3 each for priorities 0 to 2, so total 9) start together - lease once. The highest priority should win.
2. Multiple WP (3 each for priorities 0 to 2, so total 9) start at different times - priority 0 WPs start 1 minute after WPs with priorities 1 and 2. The leases should be allocated to highest available priority at each election.