### PR TITLE
Removed ReleaseLeaseAsync(CurrentLease) from workerlease

### DIFF
--- a/src/Eshopworld.WorkerProcess/WorkerLease.cs
+++ b/src/Eshopworld.WorkerProcess/WorkerLease.cs
@@ -75,8 +75,6 @@ namespace EShopworld.WorkerProcess
         {
             if (CheckLeaseExpired(CurrentLease))
             {
-                await _leaseAllocator.ReleaseLeaseAsync(CurrentLease).ConfigureAwait(false);
-
                 OnLeaseExpired();
             }
 

--- a/src/tests/EShopworld.WorkerProcess.UnitTests/WorkerLeaseTests.cs
+++ b/src/tests/EShopworld.WorkerProcess.UnitTests/WorkerLeaseTests.cs
@@ -66,7 +66,7 @@ namespace EShopworld.WorkerProcess.UnitTests
             // Assert
             eventFired.Should().BeTrue();
             _mockSlottedInterval.Verify(m => m.Calculate(new DateTime(2000, 1, 1, 12, 0, 0), TimeSpan.FromMinutes(2)));
-            _mockLeaseAllocator.Verify(m => m.ReleaseLeaseAsync(It.IsAny<ILease>()));
+            _mockLeaseAllocator.Verify(m => m.ReleaseLeaseAsync(It.IsAny<ILease>()), Times.Never);
         }
 
         [Fact, IsUnit]


### PR DESCRIPTION
The Release call is not really needed since the lease would be overridden by the next cycle of lease allocation and also all the worker processes check whether the lease is expired or not.